### PR TITLE
Fixing compilation errors on NetBSD

### DIFF
--- a/interfac/basic.cc
+++ b/interfac/basic.cc
@@ -242,7 +242,7 @@ void Win::boxtitle(coltype backg, const char *title, chtype titleAttrib)
 void Win::clreol(int y, int x)
 {
     for (int i = x; i < COLS; i++)
-        put(y, i, (chtype) ' ' | curratt);
+        put(y, i, (chtype) (' ' | curratt));
 }
 
 #ifdef USE_MOUSE
@@ -453,7 +453,7 @@ int ShadowedWin::getstring(int y, int x, char *string, int maxlen,
             offset++;
 
         for (j = offset; j < dwidth + offset; j++)
-            put(y, x + j - offset, (tmp[j] ? (unsigned char) tmp[j] :
+            put(y, x + j - offset, (chtype) (tmp[j] ? (unsigned char) tmp[j] :
                 ACS_BOARD));
         wmove(win, y, x + i - offset);
         update();


### PR DESCRIPTION
When trying to compile MultiMail on NetBSD/amd64 7.0 (using gcc version 4.8.4), I'm getting the following errors :

```
c++  -O2 -O2 -Wall -pedantic -Wno-char-subscripts -I. -DMM_MAJOR=0 -DMM_MINOR=50 -c basic.cc
basic.cc: In member function 'void Win::clreol(int, int)':
basic.cc:245:41: error: call of overloaded 'put(int&, int&, int)' is ambiguous
         put(y, i, (chtype) ' ' | curratt);
                                         ^
basic.cc:245:41: note: candidates are:
basic.cc:58:6: note: void Win::put(int, int, chtype)
 void Win::put(int y, int x, chtype z)
      ^
basic.cc:63:6: note: void Win::put(int, int, char)
 void Win::put(int y, int x, char z)
      ^
basic.cc: In member function 'int ShadowedWin::getstring(int, int, char*, int, coltype, coltype)':
basic.cc:457:27: error: call of overloaded 'put(int&, int, int)' is ambiguous
                 ACS_BOARD));
                           ^
basic.cc:457:27: note: candidates are:
basic.cc:58:6: note: void Win::put(int, int, chtype)
 void Win::put(int y, int x, chtype z)
      ^
basic.cc:63:6: note: void Win::put(int, int, char)
 void Win::put(int y, int x, char z)
      ^
*** Error code 1
```

This commit is an attempt at fixing the issue, the program compiles and build successfully with these modifications. Hopefully it doesn't break anything.
