### PR TITLE
Added support for QWKE 'To' kludge lines

### DIFF
--- a/mmail/qwk.h
+++ b/mmail/qwk.h
@@ -37,7 +37,7 @@ class qheader {
     };
 
  public:
-    char from[26], to[26], subject[72], date[15];
+    char from[72], to[72], subject[72], date[15];
     long msglen;
     int origArea;
     long msgnum, refnum;


### PR DESCRIPTION
Added support for the parsing and generating of 'To' QWKE kludge lines
with values of up to 71 characters in length.

This fixes the '25 char' to-field limit when using a QWKE compatible BBS/door.

Also fixed a couple of off-by-one errors in the maximum subject line
lengths (actually 71 printable chars, not 72).

This is a "low touch" change. I would prefer to use more macros/enums
for magic numbers (e.g. 25, 71) and change the kludge line parsing to
allow kludge lines in any order. But those improvements can come
later once this patch is accepted and tested.

Also needed, to support "From:" QWKE kludge lines.

I've actually been sitting on this patch since 2011; glad to get it
pushed out (and hopefully merged), finally.