### PR TITLE
Fix buld issue: \pdcurses assumed, $(CURS_DIR) ignored or redefined

### DIFF
--- a/Makefile.bcc
+++ b/Makefile.bcc
@@ -2,12 +2,14 @@
 # MultiMail Makefile (top) for Borland/Turbo C++
 #-----------------------------------------------
 
+!ifndef CURS_DIR
 CURS_DIR = \pdcurses
+!endif
 
 !ifdef DOS
-LIBS = spawnl.lib \pdcurses\dos\pdcurses.lib
+LIBS = spawnl.lib $(CURS_DIR)\dos\pdcurses.lib
 !else
-LIBS = \pdcurses\wincon\pdcurses.lib
+LIBS = $(CURS_DIR)\wincon\pdcurses.lib
 CC = bcc32c -q -D__WIN32__
 !endif
 

--- a/Makefile.msv
+++ b/Makefile.msv
@@ -3,7 +3,7 @@
 #--------------------------------------------------
 
 CURS_DIR = \pdcurses
-LIBS = \pdcurses\wincon\pdcurses.lib user32.lib advapi32.lib
+LIBS = $(CURS_DIR)\wincon\pdcurses.lib user32.lib advapi32.lib
 COMPILER = $(CC) -nologo -c -O2 -D__WIN32__
 
 all:	mm


### PR DESCRIPTION
Fix MSVC and BCC build issue where passing on the CURS_DIR make (BCC)
or nmake (MSVC) command-line did not work and the build was only successful
if the pdcurses was installed in "\pdcurses".

MSVC working example (assumes pdcurses.lib already built successfully):
    nmake -f Makefile.msv CURS_DIR=..\PDCurses-3.8

BCC32 working example (assumes pdcurses.lib already built successfully):
    make -f Makefile.bcc CURS_DIR=..\PDCurses-3.8