### PR TITLE
Fix warning when redefining NCURSES_SIGWINCH

### DIFF
--- a/interfac/interfac.h
+++ b/interfac/interfac.h
@@ -36,7 +36,7 @@ extern "C" {
 */
 
 #ifdef SIGWINCH
-# if defined(NCURSES_VERSION_MAJOR) && (NCURSES_VERSION_MAJOR > 4)
+# if defined(NCURSES_VERSION_MAJOR) && (NCURSES_VERSION_MAJOR > 4) && !defined(NCURSES_SIGWINCH)
 #  define NCURSES_SIGWINCH
 # endif
 # ifndef KEY_RESIZE


### PR DESCRIPTION
Seen on FreeBSD 14.3, which comes with NCurses 6.5 On this system, NCURSES_SIGWINCH is already defined in curses.h